### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4660,6 +4660,16 @@ d-references {
   <h2>Table of contents</h2>
   <ul>`;
 
+    // Helper to escape HTML entities
+    function escapeHtml(text) {
+      return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     for (const el of headings) {
       // should element be included in TOC?
       const isInTitle = el.parentElement.tagName == "D-TITLE";
@@ -4669,7 +4679,7 @@ d-references {
       const title = el.textContent;
       const link = "#" + el.getAttribute("id");
 
-      let newLine = "<li>" + '<a href="' + link + '">' + title + "</a>" + "</li>";
+      let newLine = "<li>" + '<a href="' + link + '">' + escapeHtml(title) + "</a>" + "</li>";
       if (el.tagName == "H3") {
         newLine = "<ul>" + newLine + "</ul>";
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/systemreliability/systemreliability.github.io/security/code-scanning/4](https://github.com/systemreliability/systemreliability.github.io/security/code-scanning/4)

To fix the problem, all content taken from `el.textContent` must be escaped before being interpolated into any HTML string that is later inserted using `innerHTML`. The best approach is to:  
1. Create a helper function to escape HTML meta-characters (`&`, `<`, `>`, `"`, `'`) in strings.
2. Apply this escape function to the contents of `title` before it's placed in the HTML for the ToC.
3. Limit changes only to the code involved in assembling the ToC entries (lines 4669-4678), adding the helper nearby for clarity.

Required changes:  
- Add an HTML-escaping function (e.g., `escapeHtml`).
- Replace the use of `title` in the line for HTML string interpolation to use the escaped version.
- No additional imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
