### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting assignment

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -2695,6 +2695,13 @@ d-citation-list .references .title {
           var rest = grammar.rest;
           if (rest) {
             for (var token in rest) {
+              if (
+                token === "__proto__" ||
+                token === "prototype" ||
+                token === "constructor"
+              ) {
+                continue;
+              }
               grammar[token] = rest[token];
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/systemreliability/systemreliability.github.io/security/code-scanning/2](https://github.com/systemreliability/systemreliability.github.io/security/code-scanning/2)

To fix this prototype pollution issue, we need to prevent dangerous key names like `'__proto__'`, `'prototype'`, and `'constructor'` from being used as property keys in the `for` loop at line 2697. A common and effective approach is to filter keys before assignment: skip assignment if the key is a known dangerous property. This can be achieved by adding a conditional inside the `for` loop at 2697 that continues if the key matches any of these. This blocks prototype pollution while otherwise preserving current functionality.

All edits must be limited to assets/js/distillpub/template.v2.js, inside the `tokenize` function as shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
