### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -2695,7 +2695,9 @@ d-citation-list .references .title {
           var rest = grammar.rest;
           if (rest) {
             for (var token in rest) {
-              grammar[token] = rest[token];
+              if (token !== "__proto__" && token !== "constructor" && token !== "prototype") {
+                grammar[token] = rest[token];
+              }
             }
 
             delete grammar.rest;


### PR DESCRIPTION
Potential fix for [https://github.com/systemreliability/systemreliability.github.io/security/code-scanning/1](https://github.com/systemreliability/systemreliability.github.io/security/code-scanning/1)

To prevent prototype pollution in the assignment `grammar[token] = rest[token];`, we need to ensure that untrusted keys such as `__proto__`, `constructor`, and `prototype` are never used to write properties into `grammar`. The recommended way is to skip any such key during the property iteration. The best fix is to update the loop at line 2697–2699 in `assets/js/distillpub/template.v2.js` so that before assigning, the key is checked against the list of forbidden property names: `__proto__`, `constructor`, and `prototype`. Thus, only safe keys will be merged into grammar.

No new imports or methods are strictly necessary beyond this, as a simple condition inside the for-loop is sufficient. Only lines 2697–2699 require a change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
