### PR TITLE
[codex] Harden site workflows and template escaping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,44 +62,68 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  deploy:
-    # available images: https://github.com/actions/runner-images#available-images
+  build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v4
-      - name: Setup Ruby 💎
-        uses: ruby/setup-ruby@v1
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f
         with:
           ruby-version: "3.3.5"
           bundler-cache: true
-      - name: Setup Python 🐍
-        uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.13"
-          cache: "pip" # caching pip dependencies
-      - name: Update _config.yml ⚙️
-        uses: fjogeleit/yaml-update-action@main
-        with:
-          commitChange: false
-          valueFile: "_config.yml"
-          propertyPath: "giscus.repo"
-          value: ${{ github.repository }}
-      - name: Install and Build 🔧
+          cache: "pip"
+      - name: Install and Build
         run: |
           sudo apt-get update && sudo apt-get install -y imagemagick
           pip3 install --upgrade nbconvert
           export JEKYLL_ENV=production
           bundle exec jekyll build
-      - name: Purge unused CSS 🧹
+      - name: Purge unused CSS
         run: |
           npm install -g purgecss
           purgecss -c purgecss.config.js
-      - name: Deploy 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f
+        with:
+          ruby-version: "3.3.5"
+          bundler-cache: true
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.13"
+          cache: "pip"
+      - name: Set giscus repo
+        run: |
+          ruby -ryaml -e 'path = "_config.yml"; config = YAML.load_file(path); config["giscus"] ||= {}; config["giscus"]["repo"] = ENV.fetch("GITHUB_REPOSITORY"); File.write(path, config.to_yaml)'
+      - name: Install and Build
+        run: |
+          sudo apt-get update && sudo apt-get install -y imagemagick
+          pip3 install --upgrade nbconvert
+          export JEKYLL_ENV=production
+          bundle exec jekyll build
+      - name: Purge unused CSS
+        run: |
+          npm install -g purgecss
+          purgecss -c purgecss.config.js
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f
         with:
           folder: _site

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -187,6 +187,3 @@
 {% if page.tikzjax %}
   <link defer rel="stylesheet" type="text/css" href="https://tikzjax.com/v1/fonts.css">
 {% endif %}
-
-<!-- PlumX Metrics Artifact Widget -->
-<script src="//cdn.plu.mx/widget-popup.js" async></script>

--- a/_layouts/distill.liquid
+++ b/_layouts/distill.liquid
@@ -17,18 +17,18 @@
   <d-front-matter>
     <script async type="text/json">
       {
-            "title": "{{ page.title }}",
-            "description": "{{ page.description }}",
-            "published": "{{ page.date | date: '%B %d, %Y' }}",
+            "title": {{ page.title | jsonify }},
+            "description": {{ page.description | jsonify }},
+            "published": {{ page.date | date: '%B %d, %Y' | jsonify }},
             "authors": [
               {% for author in page.authors %}
               {
-                "author": "{{ author.name }}",
-                "authorURL": "{{ author.url }}",
+                "author": {{ author.name | jsonify }},
+                "authorURL": {{ author.url | jsonify }},
                 "affiliations": [
                   {
-                    "name": "{{ author.affiliations.name }}",
-                    "url": "{{ author.affiliations.url }}"
+                    "name": {{ author.affiliations.name | jsonify }},
+                    "url": {{ author.affiliations.url | jsonify }}
                   }
                 ]
               }{% if forloop.last == false %},{% endif %}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -7,7 +7,7 @@ nav: true
 nav_order: 2
 ---
 
-<script type="text/javascript" src="//cdn.plu.mx/widget-popup.js"></script>
+<script async src="https://cdn.plu.mx/widget-popup.js"></script>
 
 <!-- _pages/publications.md -->
 


### PR DESCRIPTION
## Summary

This draft PR hardens the site build/deploy path and a couple of template surfaces found during the code review.

- Split the deploy workflow so PR builds run with repository `contents: read`, while deployment-only runs get `contents: write`.
- Removed `fjogeleit/yaml-update-action@main` and replaced it with a local Ruby one-liner in the deploy-only job.
- Pinned remaining GitHub Actions in the deploy workflow to the commit SHAs currently resolved from their version refs.
- Escaped Distill front matter values with Liquid `jsonify` before embedding them into the JSON script block.
- Removed the global PlumX popup script from the shared head include and load it only on the publications page over explicit HTTPS.

## How to check

1. Open the **Files changed** tab and confirm only these files changed:
   - `.github/workflows/deploy.yml`
   - `_layouts/distill.liquid`
   - `_includes/head.liquid`
   - `_pages/publications.md`
2. Wait for PR checks to finish. The important one for this change is the `Deploy site / build` workflow on the pull request.
3. In the Actions logs for the PR build, confirm the workflow has only read-level repository permissions and no Deploy step runs.
4. Review the rendered diff for `_layouts/distill.liquid` and verify the generated JSON values now use `jsonify`.
5. After merging, watch the push-triggered `Deploy site / deploy` workflow. It should build and deploy normally.

## Final merge path

- Keep this PR as draft until the PR build check is green.
- When satisfied, click **Ready for review**, then **Squash and merge** or **Merge pull request** into `main`.
- After merge, verify the live site and the publications page, especially publication badges/PlumX popups.

## Notes

This intentionally does not change the broader al-folio templates or content data. It focuses on the review findings with the largest risk surface: PR token permissions, mutable workflow action refs, JSON escaping in Distill front matter, and duplicate protocol-relative PlumX script loading.