### PR TITLE
[codex] Add OpenAlex and Altmetric publication badges

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -22,3 +22,5 @@ nav_order: 2
 {% bibliography %}
 
 </div>
+
+<script src="{{ '/assets/js/publication-badges.js' | relative_url }}"></script>

--- a/assets/js/publication-badges.js
+++ b/assets/js/publication-badges.js
@@ -36,9 +36,7 @@
     const apiUrl = `https://api.openalex.org/works/https://doi.org/${doi}?select=cited_by_count`;
     const link = document.createElement("a");
     link.className = "openalex-badge";
-    link.href = `https://openalex.org/search?q=${encodeURIComponent(
-      `doi:${doi}`
-    )}`;
+    link.href = `https://openalex.org/search?q=${encodeURIComponent(`doi:${doi}`)}`;
     link.setAttribute("aria-label", "OpenAlex link");
     link.setAttribute("role", "button");
     link.rel = "external nofollow noopener";
@@ -54,16 +52,14 @@
     badges.appendChild(link);
   };
 
-  document
-    .querySelectorAll(".bibliography li > .row > [id]")
-    .forEach((entry) => {
-      const doi = getDoi(entry);
-      if (!doi) return;
+  document.querySelectorAll(".bibliography li > .row > [id]").forEach((entry) => {
+    const doi = getDoi(entry);
+    if (!doi) return;
 
-      const badges = ensureBadgeRow(entry);
-      if (!badges) return;
+    const badges = ensureBadgeRow(entry);
+    if (!badges) return;
 
-      addAltmetricBadge(badges, doi);
-      addOpenAlexBadge(badges, doi);
-    });
+    addAltmetricBadge(badges, doi);
+    addOpenAlexBadge(badges, doi);
+  });
 })();

--- a/assets/js/publication-badges.js
+++ b/assets/js/publication-badges.js
@@ -2,62 +2,68 @@
   const getDoi = (entry) => {
     const doiLink = entry.querySelector('.links a[href^="https://doi.org/"]');
     if (!doiLink) return null;
-    return doiLink.href.replace(/^https:\/\/doi\.org\//, '').trim();
+    return doiLink.href.replace(/^https:\/\/doi\.org\//, "").trim();
   };
 
   const ensureBadgeRow = (entry) => {
-    let badges = entry.querySelector('.badges');
+    let badges = entry.querySelector(".badges");
     if (badges) return badges;
 
-    const links = entry.querySelector('.links');
+    const links = entry.querySelector(".links");
     if (!links) return null;
 
-    badges = document.createElement('div');
-    badges.className = 'badges d-inline-flex align-items-center';
-    badges.style.gap = '0.35rem';
-    links.insertAdjacentElement('afterend', badges);
+    badges = document.createElement("div");
+    badges.className = "badges d-inline-flex align-items-center";
+    badges.style.gap = "0.35rem";
+    links.insertAdjacentElement("afterend", badges);
     return badges;
   };
 
   const addAltmetricBadge = (badges, doi) => {
-    if (badges.querySelector('.altmetric-embed')) return;
+    if (badges.querySelector(".altmetric-embed")) return;
 
-    const badge = document.createElement('span');
-    badge.className = 'altmetric-embed';
-    badge.dataset.badgeType = '2';
-    badge.dataset.badgePopover = 'right';
+    const badge = document.createElement("span");
+    badge.className = "altmetric-embed";
+    badge.dataset.badgeType = "2";
+    badge.dataset.badgePopover = "right";
     badge.dataset.doi = doi;
     badges.prepend(badge);
   };
 
   const addOpenAlexBadge = (badges, doi) => {
-    if (badges.querySelector('.openalex-badge')) return;
+    if (badges.querySelector(".openalex-badge")) return;
 
     const apiUrl = `https://api.openalex.org/works/https://doi.org/${doi}?select=cited_by_count`;
-    const link = document.createElement('a');
-    link.className = 'openalex-badge';
-    link.href = `https://openalex.org/search?q=${encodeURIComponent(`doi:${doi}`)}`;
-    link.setAttribute('aria-label', 'OpenAlex link');
-    link.setAttribute('role', 'button');
-    link.rel = 'external nofollow noopener';
-    link.target = '_blank';
+    const link = document.createElement("a");
+    link.className = "openalex-badge";
+    link.href = `https://openalex.org/search?q=${encodeURIComponent(
+      `doi:${doi}`
+    )}`;
+    link.setAttribute("aria-label", "OpenAlex link");
+    link.setAttribute("role", "button");
+    link.rel = "external nofollow noopener";
+    link.target = "_blank";
 
-    const image = document.createElement('img');
-    image.src = `https://img.shields.io/badge/dynamic/json?url=${encodeURIComponent(apiUrl)}&query=$.cited_by_count&label=OpenAlex&color=2f7f6f&labelColor=beige`;
-    image.alt = 'OpenAlex citation count';
+    const image = document.createElement("img");
+    image.src = `https://img.shields.io/badge/dynamic/json?url=${encodeURIComponent(
+      apiUrl
+    )}&query=$.cited_by_count&label=OpenAlex&color=2f7f6f&labelColor=beige`;
+    image.alt = "OpenAlex citation count";
 
     link.appendChild(image);
     badges.appendChild(link);
   };
 
-  document.querySelectorAll('.bibliography li > .row > [id]').forEach((entry) => {
-    const doi = getDoi(entry);
-    if (!doi) return;
+  document
+    .querySelectorAll(".bibliography li > .row > [id]")
+    .forEach((entry) => {
+      const doi = getDoi(entry);
+      if (!doi) return;
 
-    const badges = ensureBadgeRow(entry);
-    if (!badges) return;
+      const badges = ensureBadgeRow(entry);
+      if (!badges) return;
 
-    addAltmetricBadge(badges, doi);
-    addOpenAlexBadge(badges, doi);
-  });
+      addAltmetricBadge(badges, doi);
+      addOpenAlexBadge(badges, doi);
+    });
 })();

--- a/assets/js/publication-badges.js
+++ b/assets/js/publication-badges.js
@@ -1,0 +1,63 @@
+(() => {
+  const getDoi = (entry) => {
+    const doiLink = entry.querySelector('.links a[href^="https://doi.org/"]');
+    if (!doiLink) return null;
+    return doiLink.href.replace(/^https:\/\/doi\.org\//, '').trim();
+  };
+
+  const ensureBadgeRow = (entry) => {
+    let badges = entry.querySelector('.badges');
+    if (badges) return badges;
+
+    const links = entry.querySelector('.links');
+    if (!links) return null;
+
+    badges = document.createElement('div');
+    badges.className = 'badges d-inline-flex align-items-center';
+    badges.style.gap = '0.35rem';
+    links.insertAdjacentElement('afterend', badges);
+    return badges;
+  };
+
+  const addAltmetricBadge = (badges, doi) => {
+    if (badges.querySelector('.altmetric-embed')) return;
+
+    const badge = document.createElement('span');
+    badge.className = 'altmetric-embed';
+    badge.dataset.badgeType = '2';
+    badge.dataset.badgePopover = 'right';
+    badge.dataset.doi = doi;
+    badges.prepend(badge);
+  };
+
+  const addOpenAlexBadge = (badges, doi) => {
+    if (badges.querySelector('.openalex-badge')) return;
+
+    const apiUrl = `https://api.openalex.org/works/https://doi.org/${doi}?select=cited_by_count`;
+    const link = document.createElement('a');
+    link.className = 'openalex-badge';
+    link.href = `https://openalex.org/search?q=${encodeURIComponent(`doi:${doi}`)}`;
+    link.setAttribute('aria-label', 'OpenAlex link');
+    link.setAttribute('role', 'button');
+    link.rel = 'external nofollow noopener';
+    link.target = '_blank';
+
+    const image = document.createElement('img');
+    image.src = `https://img.shields.io/badge/dynamic/json?url=${encodeURIComponent(apiUrl)}&query=$.cited_by_count&label=OpenAlex&color=2f7f6f&labelColor=beige`;
+    image.alt = 'OpenAlex citation count';
+
+    link.appendChild(image);
+    badges.appendChild(link);
+  };
+
+  document.querySelectorAll('.bibliography li > .row > [id]').forEach((entry) => {
+    const doi = getDoi(entry);
+    if (!doi) return;
+
+    const badges = ensureBadgeRow(entry);
+    if (!badges) return;
+
+    addAltmetricBadge(badges, doi);
+    addOpenAlexBadge(badges, doi);
+  });
+})();


### PR DESCRIPTION
## Summary

- Add a publications-page script that augments DOI-bearing bibliography entries with Altmetric badges.
- Add OpenAlex citation-count badges using Shields dynamic JSON against the OpenAlex Works API.
- Preserve the existing Google Scholar, Dimensions, and PlumX badges.

## How to check

1. Review the two changed files:
   - `_pages/publications.md`
   - `assets/js/publication-badges.js`
2. Wait for the PR build check to finish.
3. Preview or deploy the branch and open `/publications/`.
4. Confirm DOI-bearing entries show the intended badge mix: Google Scholar, OpenAlex, Dimensions, PlumX, and Altmetric.

## Notes

This keeps the enhancement scoped to `/publications/` instead of changing the shared bibliography layout globally.