### PR TITLE
[codex] Refine publication badge ordering and links

### DIFF
--- a/assets/js/publication-badges.js
+++ b/assets/js/publication-badges.js
@@ -33,35 +33,36 @@
 
   const getOpenAlexUiUrl = (workId) => workId.replace("https://api.openalex.org/", "https://openalex.org/");
 
-  const resolveOpenAlexLink = async (link, apiUrl) => {
+  const fetchOpenAlexWork = async (apiUrl) => {
     try {
       const response = await fetch(apiUrl);
-      if (!response.ok) return;
+      if (!response.ok) return null;
 
       const work = await response.json();
-      if (work.id) link.href = getOpenAlexUiUrl(work.id);
+      return work.id && Number.isFinite(work.cited_by_count) ? work : null;
     } catch {
-      // Keep the DOI fallback if OpenAlex lookup is unavailable.
+      return null;
     }
   };
 
-  const addOpenAlexBadge = (badges, doi) => {
+  const addOpenAlexBadge = async (badges, doi) => {
     if (badges.querySelector(".openalex-badge")) return;
 
     const apiUrl = `https://api.openalex.org/works/https://doi.org/${doi}?select=id,cited_by_count`;
+    const work = await fetchOpenAlexWork(apiUrl);
+    if (!work) return;
+
     const link = document.createElement("a");
     link.className = "openalex-badge";
-    link.href = `https://doi.org/${doi}`;
+    link.href = getOpenAlexUiUrl(work.id);
     link.setAttribute("aria-label", "OpenAlex link");
     link.setAttribute("role", "button");
     link.rel = "external nofollow noopener";
     link.target = "_blank";
 
     const image = document.createElement("img");
-    image.src = `https://img.shields.io/badge/dynamic/json?url=${encodeURIComponent(
-      apiUrl
-    )}&query=$.cited_by_count&label=OpenAlex&color=2f7f6f&labelColor=beige`;
-    image.alt = "OpenAlex citation count";
+    image.src = `https://img.shields.io/badge/OpenAlex-${work.cited_by_count}-2f7f6f?labelColor=beige`;
+    image.alt = `${work.cited_by_count} OpenAlex citations`;
 
     link.appendChild(image);
 
@@ -71,8 +72,6 @@
     } else {
       badges.appendChild(link);
     }
-
-    resolveOpenAlexLink(link, apiUrl);
   };
 
   document.querySelectorAll(".bibliography li > .row > [id]").forEach((entry) => {

--- a/assets/js/publication-badges.js
+++ b/assets/js/publication-badges.js
@@ -26,17 +26,32 @@
     badge.className = "altmetric-embed";
     badge.dataset.badgeType = "2";
     badge.dataset.badgePopover = "right";
+    badge.dataset.hideNoMentions = "true";
     badge.dataset.doi = doi;
     badges.prepend(badge);
+  };
+
+  const getOpenAlexUiUrl = (workId) => workId.replace("https://api.openalex.org/", "https://openalex.org/");
+
+  const resolveOpenAlexLink = async (link, apiUrl) => {
+    try {
+      const response = await fetch(apiUrl);
+      if (!response.ok) return;
+
+      const work = await response.json();
+      if (work.id) link.href = getOpenAlexUiUrl(work.id);
+    } catch {
+      // Keep the DOI fallback if OpenAlex lookup is unavailable.
+    }
   };
 
   const addOpenAlexBadge = (badges, doi) => {
     if (badges.querySelector(".openalex-badge")) return;
 
-    const apiUrl = `https://api.openalex.org/works/https://doi.org/${doi}?select=cited_by_count`;
+    const apiUrl = `https://api.openalex.org/works/https://doi.org/${doi}?select=id,cited_by_count`;
     const link = document.createElement("a");
     link.className = "openalex-badge";
-    link.href = `https://openalex.org/search?q=${encodeURIComponent(`doi:${doi}`)}`;
+    link.href = `https://doi.org/${doi}`;
     link.setAttribute("aria-label", "OpenAlex link");
     link.setAttribute("role", "button");
     link.rel = "external nofollow noopener";
@@ -49,7 +64,15 @@
     image.alt = "OpenAlex citation count";
 
     link.appendChild(image);
-    badges.appendChild(link);
+
+    const plumxBadge = badges.querySelector(".plumx-plum-print-popup");
+    if (plumxBadge) {
+      badges.insertBefore(link, plumxBadge);
+    } else {
+      badges.appendChild(link);
+    }
+
+    resolveOpenAlexLink(link, apiUrl);
   };
 
   document.querySelectorAll(".bibliography li > .row > [id]").forEach((entry) => {


### PR DESCRIPTION
## Summary

- Hide Altmetric badges when an item has no mentions using `data-hide-no-mentions`.
- Insert OpenAlex before PlumX in the publication badge row.
- Resolve OpenAlex badge links through the OpenAlex API so clicks go to the actual OpenAlex work page when available, with DOI as a safe fallback.

## How to check

1. Wait for the PR checks to finish, especially Prettier and Deploy site / build.
2. Open `/publications/` on the preview/deployed branch.
3. Confirm badge ordering around OpenAlex and PlumX.
4. Click an OpenAlex badge and confirm it lands on the matching OpenAlex work page after the client-side lookup completes.