### PR TITLE
Tune Dimensions badge spacing

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -298,7 +298,7 @@
         or entry_has_plumx_badge
         or entry_has_inspirehep_badge
       %}
-        <div class="badges d-inline-flex align-items-center" style="gap:0.35rem;">
+        <div class="badges d-inline-flex align-items-center">
           {% if site.enable_publication_badges.altmetric and entry_has_altmetric_badge %}
             <span
               class="altmetric-embed"
@@ -329,7 +329,6 @@
                 data-pmid="{{ entry.pmid }}"
               {% endif %}
               data-style="small_rectangle"
-              style="margin-bottom: 3px;"
             ></span>
           {% endif %}
           {% if entry_has_openalex_badge %}

--- a/_sass/_publication-badges.scss
+++ b/_sass/_publication-badges.scss
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Styles for publication metric badges.
+ ******************************************************************************/
+
+.publications {
+  ol.bibliography {
+    li {
+      .badges {
+        --publication-badge-gap: 0.3rem;
+        --dimensions-badge-scale: 0.92;
+        --dimensions-badge-offset-y: 1px;
+
+        align-items: center;
+        gap: var(--publication-badge-gap);
+
+        span {
+          padding-right: 0;
+        }
+
+        .__dimensions_badge_embed__ {
+          line-height: 1;
+          transform: translateY(var(--dimensions-badge-offset-y)) scale(var(--dimensions-badge-scale));
+          transform-origin: left center;
+
+          iframe,
+          img {
+            vertical-align: middle;
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,6 +11,7 @@ $max-content-width: {{ site.max_width }};
   "themes",
   "layout",
   "base",
+  "publication-badges",
   "distill",
   "cv",
   "tabs",


### PR DESCRIPTION
## Summary
- Move publication badge gap styling out of inline Liquid into Sass
- Add a publication badge stylesheet with CSS variables for badge gap, Dimensions scale, and vertical offset
- Remove Dimensions inline margin so spacing/size can be adjusted centrally

## Verification
- Ran `bundle exec jekyll build`
- Ran `git diff --check origin/main..HEAD`