### PR TITLE
Increase OpenAlex to Google Scholar badge gap

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -347,6 +347,7 @@
           {% endif %}
           {% if site.enable_publication_badges.google_scholar and entry_has_google_scholar_badge %}
             <a
+              class="google-scholar-badge"
               href="https://scholar.google.com/citations?view_op=view_citation&hl=en&user={{ site.scholar_userid }}&citation_for_view={{ site.scholar_userid }}:{{ entry.google_scholar_id }}"
               aria-label="Google Scholar link"
               role="button"

--- a/_sass/_publication-badges.scss
+++ b/_sass/_publication-badges.scss
@@ -9,6 +9,7 @@
         --publication-badge-gap: 0.1rem;
         --dimensions-badge-scale: 0.92;
         --dimensions-badge-offset-y: 1px;
+        --openalex-scholar-gap: 0.35rem;
 
         align-items: center;
         gap: var(--publication-badge-gap);
@@ -26,6 +27,10 @@
           img {
             vertical-align: middle;
           }
+        }
+
+        .openalex-badge + .google-scholar-badge {
+          margin-left: var(--openalex-scholar-gap);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add a Google Scholar badge class
- Add `--openalex-scholar-gap` to control extra spacing only when Google Scholar follows OpenAlex

## Verification
- Ran `bundle exec jekyll build`
- Ran `git diff --check`