### PR TITLE
Fix publication badge spacing and PlumX loading

### DIFF
--- a/_data/citations.yml
+++ b/_data/citations.yml
@@ -1,65 +1,65 @@
 metadata:
-  last_updated: '2026-05-01 00:00:00'
+  last_updated: "2026-05-01 00:00:00"
   fetch_status: failed
-  fetch_failed_at: '2026-05-04 04:12:40'
+  fetch_failed_at: "2026-05-04 04:12:40"
   fetch_error: All Google Scholar fetch retries failed
 papers:
   cLfMY9wAAAAJ:ufrVoPGSRksC:
     title: Efficient seismic reliability and fragility analysis of lifeline networks
       using subset simulation
-    year: '2025'
+    year: "2025"
     citations: 37
   cLfMY9wAAAAJ:UeHWp8X0CEIC:
     title: Risk-informed operation and maintenance of complex lifeline systems using
       parallelized multi-agent deep Q-network
-    year: '2023'
+    year: "2023"
     citations: 24
   cLfMY9wAAAAJ:qjMakFHDy7sC:
     title: Multi-scale seismic reliability assessment of networks by centrality-based
       selective recursive decomposition algorithm
-    year: '2021'
+    year: "2021"
     citations: 24
   cLfMY9wAAAAJ:b0M2c_1WBrUC:
-    title: 'Seismic performance management of aging road facilities in Korea: Part
-      2 - decision-making support technology and its application'
-    year: '2024'
+    title: "Seismic performance management of aging road facilities in Korea: Part
+      2 - decision-making support technology and its application"
+    year: "2024"
     citations: 4
   cLfMY9wAAAAJ:Y5dfb0dijaUC:
     title: Network reliability analysis and complexity quantification using Bayesian
       network and dual representation
-    year: '2023'
+    year: "2023"
     citations: 2
   cLfMY9wAAAAJ:tkaPQYYpVKoC:
     title: Dual graph-based Bayesian network modeling with Rao-Blackwellization for
       seismic reliability and complexity quantification of network connectivity
-    year: '2025'
+    year: "2025"
     citations: 2
   cLfMY9wAAAAJ:hMod-77fHWUC:
     title: Development of seismic reliability analysis methods for large-scale infrastructure
       networks
-    year: '2023'
+    year: "2023"
     citations: 0
   cLfMY9wAAAAJ:WF5omc3nYNoC:
     title: Maintenance decision-making for infrastructure systems using clustering-based
       cooperative multi-agent deep Q-network
-    year: '2022'
+    year: "2022"
     citations: 0
   cLfMY9wAAAAJ:WqliGbK-hY8C:
     title: Seismic fragility curves of lifeline networks based on subset simulation
-    year: '2024'
+    year: "2024"
     citations: 0
   cLfMY9wAAAAJ:D_sINldO8mEC:
     title: Development of seismic reliability analysis methods for large-scale infrastructure
       networks
-    year: '2023'
+    year: "2023"
     citations: 0
   cLfMY9wAAAAJ:q3oQSFYPqjQC:
     title: Development of centrality-based selective recursive decomposition algorithm
       using network simplification
-    year: '2022'
+    year: "2022"
     citations: 0
   cLfMY9wAAAAJ:BrmTIyaxlBUC:
     title: Centrality-based selective recursive decomposition algorithm for efficient
       network reliability analysis
-    year: '2020'
+    year: "2020"
     citations: 0

--- a/_includes/scripts.liquid
+++ b/_includes/scripts.liquid
@@ -195,7 +195,7 @@
   <script async src="https://badge.dimensions.ai/badge.js"></script>
 {% endif %}
 {% if site.enable_publication_badges.plumx %}
-  <script type="text/javascript" src="//cdn.plu.mx/widget-details.js"></script>
+  <script async src="https://cdn.plu.mx/widget-popup.js"></script>
 {% endif %}
 
 {% if site.enable_math %}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -7,8 +7,6 @@ nav: true
 nav_order: 2
 ---
 
-<script async src="https://cdn.plu.mx/widget-popup.js"></script>
-
 <!-- _pages/publications.md -->
 
 {% if site.data.citations.metadata.last_updated %}

--- a/_plugins/hide-custom-bibtex.rb
+++ b/_plugins/hide-custom-bibtex.rb
@@ -1,11 +1,12 @@
 module Jekyll
   module HideCustomBibtex
     def hideCustomBibtex(input)
-	    keywords = @context.registers[:site].config['filtered_bibtex_keywords']
+      keywords = Array(@context.registers[:site].config['filtered_bibtex_keywords'])
+      keywords |= ['openalex_id']
 
-	    keywords.each do |keyword|
-		    input = input.gsub(/^.*\b#{keyword}\b *= *\{.*$\n/, '')
-	    end
+      keywords.each do |keyword|
+        input = input.gsub(/^.*\b#{keyword}\b *= *\{.*$\n/, '')
+      end
 
       # Clean superscripts in author lists
       input = input.gsub(/^.*\bauthor\b *= *\{.*$\n/) { |line| line.gsub(/[*†‡§¶‖&^]/, '') }

--- a/_sass/_publication-badges.scss
+++ b/_sass/_publication-badges.scss
@@ -9,7 +9,7 @@
         --publication-badge-gap: 0rem;
         --dimensions-badge-scale: 0.92;
         --dimensions-badge-offset-y: 1px;
-        --openalex-scholar-gap: 0.5rem;
+        --openalex-scholar-gap: 0.8rem;
 
         align-items: center;
         gap: var(--publication-badge-gap);
@@ -29,7 +29,7 @@
           }
         }
 
-        .openalex-badge + .google-scholar-badge {
+        .openalex-badge ~ .google-scholar-badge {
           margin-left: var(--openalex-scholar-gap);
         }
       }


### PR DESCRIPTION
## Summary
- Increase and broaden the OpenAlex-to-Google Scholar badge spacing rule
- Load the PlumX popup widget globally so homepage selected publications render PlumX badges like the publications page
- Remove the duplicate PlumX script from the publications page
- Hide `openalex_id` from expanded BibTeX output through the custom BibTeX filter

## Verification
- Ran `git diff --check`
- Ran `bundle exec jekyll build`
- Confirmed generated homepage includes PlumX badge markup and `widget-popup.js`
- Confirmed generated homepage/publications BibTeX output no longer contains `openalex_id`

## Notes
Local Jekyll build completed successfully. The local machine still lacks ImageMagick `convert`, so the existing responsive image generation step logged `convert: command not found` warnings while Jekyll exited successfully.