### PR TITLE
Fix publication badge spacing cache bust

### DIFF
--- a/_plugins/cache-bust.rb
+++ b/_plugins/cache-bust.rb
@@ -43,7 +43,7 @@ module Jekyll
     end
 
     def bust_css_cache(file_name)
-      CacheDigester.new(file_name: file_name, directory: 'assets/_sass').digest!
+      CacheDigester.new(file_name: file_name, directory: '_sass').digest!
     end
   end
 end

--- a/_sass/_publication-badges.scss
+++ b/_sass/_publication-badges.scss
@@ -9,7 +9,7 @@
         --publication-badge-gap: 0rem;
         --dimensions-badge-scale: 0.92;
         --dimensions-badge-offset-y: 1px;
-        --openalex-scholar-gap: 0.8rem;
+        --openalex-scholar-gap: 0.9rem;
 
         align-items: center;
         gap: var(--publication-badge-gap);
@@ -29,8 +29,18 @@
           }
         }
 
+        .openalex-badge,
+        .google-scholar-badge {
+          display: inline-flex;
+          align-items: center;
+
+          img {
+            display: block;
+          }
+        }
+
         .openalex-badge ~ .google-scholar-badge {
-          margin-left: var(--openalex-scholar-gap);
+          margin-left: var(--openalex-scholar-gap, 0.9rem) !important;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Increase the OpenAlex-to-Google Scholar badge gap to `0.9rem` and make the rule `!important`
- Normalize OpenAlex/Google Scholar badge links as inline-flex so shield images align cleanly
- Fix the CSS cache-busting plugin to hash the actual `_sass` directory instead of the nonexistent `assets/_sass`

## Verification
- Ran `git diff --check`
- Ran `bundle exec jekyll build`
- Confirmed generated pages now reference a changed `main.css` cache hash
- Confirmed generated CSS contains the stronger OpenAlex-to-Google Scholar spacing rule

## Notes
Local Jekyll build completed successfully. The local machine still lacks ImageMagick `convert`, so responsive image generation logged existing `convert: command not found` warnings while Jekyll exited successfully.