### PR TITLE
Adjust OpenAlex badge spacing

### DIFF
--- a/_sass/_publication-badges.scss
+++ b/_sass/_publication-badges.scss
@@ -9,7 +9,9 @@
         --publication-badge-gap: 0rem;
         --dimensions-badge-scale: 1.05;
         --dimensions-badge-offset-y: 1px;
-        --openalex-scholar-gap: 0.9rem;
+        --dimensions-openalex-gap: 0.35rem;
+        --openalex-scholar-gap: 0.45rem;
+        --metric-badge-height: 20px;
 
         align-items: center;
         gap: var(--publication-badge-gap);
@@ -29,24 +31,25 @@
           }
         }
 
-        .openalex-badge img {
-          height: 20px;
-          width: auto;
-        }
-        
-        .google-scholar-badge img {
-          height: 20px;
-          width: auto;
+        .openalex-badge,
+        .google-scholar-badge {
           display: inline-flex;
           align-items: center;
+        }
 
-          img {
-            display: block;
-          }
+        .openalex-badge {
+          margin-left: var(--dimensions-openalex-gap);
+        }
+
+        .openalex-badge img,
+        .google-scholar-badge img {
+          display: block;
+          height: var(--metric-badge-height);
+          width: auto;
         }
 
         .openalex-badge ~ .google-scholar-badge {
-          margin-left: var(--openalex-scholar-gap, 0.9rem) !important;
+          margin-left: var(--openalex-scholar-gap, 0.45rem) !important;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add a separate `--dimensions-openalex-gap` variable to move OpenAlex away from Dimensions
- Reduce `--openalex-scholar-gap` so OpenAlex sits closer to Google Scholar
- Clean up OpenAlex/Google Scholar badge image sizing into a shared `--metric-badge-height`

## Verification
- Ran `git diff --check`
- Ran `bundle exec jekyll build`
- Confirmed generated CSS includes the new spacing variables and rules

## Notes
Local Jekyll build completed successfully. The local machine still lacks ImageMagick `convert`, so responsive image generation logged existing `convert: command not found` warnings while Jekyll exited successfully.